### PR TITLE
Add back button

### DIFF
--- a/mal_randomizer.py
+++ b/mal_randomizer.py
@@ -13,6 +13,14 @@
 # *add API call counter.[]
 #
 #
+# HOW THE BACK/NEXT BUTTONS should work
+# the buttons should only show up if the stting is toggle on
+# when random output is generated, save to a history tracker before displaying it
+# back and next buttons allow moving along this tracker
+# save pictures locally!? make API call each time? best to store the whole output?
+# hitting randomize should clear out all saved output that would be "next"
+# this possibly requires creating a new structure for storing output.
+#
 #
 # API method:
 #  1 per-username API call to get the list
@@ -40,30 +48,39 @@ import io
 
 if __name__ == '__main__':
 
+    # Globa variables
     list_titles = list()
     list_id = list()
     list_coverImg = list()
+    list_history = list("","","")
+
     no_movies = False
     only_movies = False
+    allow_back = False
+
     rnd_Title, rnd_id, rnd_CoverURL = '', '', ''
     prevAPIcall = ""
     prevXMLfile = ""
-    prevOutput = ("","","")
+    #prevOutput = ("","","")
+
     MALURL = "https://myanimelist.net/"
+
+    # load the default iamge
     CurrentDir = getcwd()
-    # default image when there is no cover art to display.
     # this method should work with auto-py-to-exe or pyinstaller.
     default_pngPath = path.join((getattr(sys, '_MEIPASS', path.dirname(path.abspath('designismypassion.png')))), 'designismypassion.png')
     pil_im = Image.open(default_pngPath)
     d = io.BytesIO()
     pil_im.save(d, 'png')
     default_png = d.getvalue()
+
     # if there is no config file, create one
     if not path.exists(CurrentDir + "/config.py"):
         with open("config.py", "w+") as file:
             file.write("API_key = \"******\"")
             file.close()
-    # manually reads the Api key from the config file instead of importing it...
+
+    # manually read the Api key from the config file instead of importing it...
     # otherwise the value would be locked in when bundling the app.
     with open("config.py", "r") as file:
         API_key = file.read(-1)
@@ -75,6 +92,7 @@ if __name__ == '__main__':
 # ------------------------------------------------------------------------------
 
     # Yields every value in a dict where its key matches the argument.
+    # https://stackoverflow.com/a/29652561/15460873
     def gen_dict_extract(var, key):
             if isinstance(var, dict):
                 for dictKey, dictValue in var.items():  # for every (key:value) pair in var...
@@ -363,12 +381,14 @@ if __name__ == '__main__':
                    [Gooey.Checkbox('Show english title', default=False, key='-showEng-')],
                    [Gooey.Checkbox('Show mean score', default=True, key='-showScore-')],
                    [Gooey.Checkbox('Show duration', default=True, key='-showDuration-')],
-                   [Gooey.Checkbox('Show additional info', default=False,  key='-showInfo-')]]
+                   [Gooey.Checkbox('Show additional info', default=False,  key='-showInfo-')],
+                   [Gooey.Checkbox('Enable back/next buttons', default=False, key='-allowBack-')]]
     # The main layout.
     layout = [
         [Gooey.TabGroup([[Gooey.Tab('Main', tab1_layout), 
                           Gooey.Tab('Settings', tab2_layout)]])],
-        [Gooey.Push(),Gooey.Button('Back', disabled=True), Gooey.Button('Randomize!', bind_return_key=True), Gooey.Button('Exit')]]
+        [Gooey.Push(),Gooey.Button('Back', disabled=True), Gooey.Button('Next', disabled=True), 
+         Gooey.Button('Randomize!', bind_return_key=True), Gooey.Button('Exit')]]
     window = Gooey.Window('MAL Randomizer', layout)  # Create the window.
 
     # Loop listening for GUI events.

--- a/mal_randomizer.py
+++ b/mal_randomizer.py
@@ -7,7 +7,6 @@
 # >notes from linux run:
 #  # pip isntall pysimplegui + apt install python3-tk
 # 
-# *split functions into multiple files?[]
 # *Force cover art image size to avoid window resizing. []
 # *use global variables to reduce number of arguments? []
 # *add API call counter.[]
@@ -52,7 +51,7 @@ if __name__ == '__main__':
     list_titles = list()
     list_id = list()
     list_coverImg = list()
-    list_history = list("","","")
+    list_history = list()
 
     no_movies = False
     only_movies = False
@@ -61,7 +60,6 @@ if __name__ == '__main__':
     rnd_Title, rnd_id, rnd_CoverURL = '', '', ''
     prevAPIcall = ""
     prevXMLfile = ""
-    #prevOutput = ("","","")
 
     MALURL = "https://myanimelist.net/"
 
@@ -137,15 +135,6 @@ if __name__ == '__main__':
         window['-OUTPUT_rating-'].update("")
         window['-OUTPUT_genre-'].update("")
         MALURL = 'https://myanimelist.net/'
-        
-    # Saves the current output for the back button as a tuple. (title, id, coverURL)
-    # call with empty strings to return the last saved output as a tuple.
-    def SaveOutput(AnimeTitle, AnimeID, AnimeCoverURL):
-        global prevOutput
-        if AnimeTitle == "" and AnimeID == "" and AnimeCoverURL == "":
-            return prevOutput
-        else:
-            prevOutput = (AnimeTitle, AnimeID, AnimeCoverURL)
 
     # Updates the GUI with the current output.
     # this function always makes 1 API call to get additional anime info.
@@ -374,7 +363,7 @@ if __name__ == '__main__':
     # The settings tab.
     tab2_layout = [[Gooey.Push(), Gooey.T('API Key:'),
                      Gooey.In(key='-apiKeyInput-', default_text=API_key , password_char='●', right_click_menu=[[''], ['Paste API key']]),
-                     Gooey.Button('Save', key='-SAVE-')],
+                     Gooey.Button('Save', key='-saveApiKey-')],
                    [Gooey.Checkbox('Use local XML file', key='-useXML-', enable_events=True),
                      Gooey.Push(), Gooey.T('XML file:'),
                      Gooey.Input(key='-XMLfileInput-'), Gooey.FileBrowse()],
@@ -414,12 +403,12 @@ if __name__ == '__main__':
             SettingsChanged()
         if event == '-showInfo-':
             SettingsChanged()
-        if event in ('-SAVE-'):
+        if event in ('-saveApiKey-'):
             API_key = values['-apiKeyInput-']
             with open('config.py', 'w+') as file:
                 file.write("API_key = \"" + API_key + "\"")
         if event in ('-OUTPUT_IMG-'):
-            # user clicks on the cover image.
+            # if user clicks on the cover image.
             webbrowser.open_new_tab(MALURL)
         if event == 'Randomize!':
             if values['-useXML-'] == True:
@@ -444,25 +433,9 @@ if __name__ == '__main__':
                     ClearOutput()
                     window['-OUTPUT-'].update("Error: No anime found in PTW list.")
                     continue
-            # save current output, enable the back button.
-            SaveOutput(rnd_Title, rnd_id, rnd_CoverURL)
-            window['Back'].update(disabled=False)
             # Get the random anime from the list.
             rnd_Title, rnd_id, rnd_CoverURL = GetRandomAnime()
             # Display the anime in the GUI.           
-            displayOutput(rnd_Title, rnd_id, rnd_CoverURL)            
-        if event == 'Back':
-            window['Back'].update(disabled=True)#<---- Prevent multiple  uses of the back button. 
-            try:
-                if prevOutput[1] != '':
-                    displayOutput(prevOutput[0], prevOutput[1], prevOutput[2])
-                    _buffer = (rnd_Title, rnd_id, rnd_CoverURL)
-                    rnd_Title, rnd_id, rnd_CoverURL = prevOutput
-                    prevOutput = _buffer
-                else:
-                    ClearOutput()
-            except:
-                ClearOutput()
-                window['-OUTPUT-'].update("Error: Back button error.")
+            displayOutput(rnd_Title, rnd_id, rnd_CoverURL)
         if event in (Gooey.WIN_CLOSED, 'Exit'):
             sys.exit(0)


### PR DESCRIPTION
This commit finally adds fully functional Back/Next buttons

it stores the output of GetRandomAnime as a tuple, when the back or next buttons are pressed the values in the corresponding tuple are passed to DisplayOutput, which makes an API call for additional details as usual.  
Consider refactoring the function in the future to avoid these repeat calls 

Hitting the randomize button while looking at a previous anime in the history will slice the list and make the new anime the new top of the stack, similar to how web browser history works in a given tab.

There is no limit to the size of the stack, which could lead to an memory overflow as the size of the stack approaches 4gb, but I suspect the MAL API key might run out its monthly call limit before that happened.